### PR TITLE
スキル「宝具タイプ変更」に対応、エミヤのNP計算を可能にする

### DIFF
--- a/pages/npaquisition-calculation.vue
+++ b/pages/npaquisition-calculation.vue
@@ -44,7 +44,7 @@
               label="サーヴァント"
               :items="filteredCharacters"
               :disabled="!characterClass"
-              placeholder="先にクラスを選択してください"
+              placeholder="先にクラスを選択"
               class="mr-4"
               color="teal accent-4"
               @input="onChangeVal(characterName)"
@@ -52,13 +52,13 @@
           </v-col>
 
           <v-col cols="4" sm="4" md="2">
-            <v-text-field
+            <v-select
               v-model="servantNpType"
-              label="宝具タイプ"
-              disabled
-              placeholder="自動"
+              label="宝具"
+              :items="selectServantNpType"
               class="mr-4"
-            ></v-text-field>
+              color="teal accent-4"
+            ></v-select>
           </v-col>
 
           <v-col cols="4" sm="4" md="2">
@@ -282,6 +282,7 @@ export default {
       characterClass: '', // 選択されたクラス
       characterName: '', // 選択されたキャラクター
       servantNpType: '', // キャラクターの宝具タイプ
+      selectServantNpType: ['Arts', 'Quick', 'Buster'],
       npRate: '', // NPレート
       npHits: 0, // 宝具ヒット回数
       overkillHits: 0,

--- a/pages/npatk-calculation.vue
+++ b/pages/npatk-calculation.vue
@@ -44,7 +44,7 @@
               label="サーヴァント"
               :items="filteredCharacters"
               :disabled="!characterClass"
-              placeholder="先にクラスを選択してください"
+              placeholder="先にクラスを選択"
               class="mr-4"
               color="teal accent-4"
               @input="onChangeVal(characterName)"
@@ -52,13 +52,13 @@
           </v-col>
 
           <v-col cols="4" sm="2" md="2">
-            <v-text-field
+            <v-select
               v-model="servantNpType"
-              label="宝具タイプ"
-              disabled
-              placeholder="自動"
-              class="mr-4"
-            ></v-text-field>
+              label="宝具"
+              :items="selectServantNpType"
+              class="mr-3"
+              color="teal accent-4"
+            ></v-select>
           </v-col>
 
           <v-col cols="4" sm="3" md="3">
@@ -67,7 +67,7 @@
               label="宝具Lv."
               :items="items.npChargeLevel"
               :disabled="!characterName"
-              class="mr-4"
+              class="mr-3"
               color="teal accent-4"
               @change="onChangeNpmultiplier(npChargeLv)"
             ></v-select>
@@ -436,6 +436,7 @@ export default {
       npmultiplier: [], // キャラクターの宝具倍率の配列
       characterNpmultiplier: '', // 配列から取り出したサーヴァントの宝具倍率
       servantNpType: '', // キャラクターの宝具タイプ
+      selectServantNpType: ['Buster', 'Arts', 'Quick'],
       items: {
         class: [
           'セイバー',

--- a/store/characters.js
+++ b/store/characters.js
@@ -25,7 +25,10 @@ export const getters = {
   artsQuickCahracters: (state) => {
     return _.sortBy(
       state.characters.filter(
-        (character) => character.card === 'A' || character.card === 'Q'
+        (character) =>
+          character.card === 'A' ||
+          character.card === 'Q' ||
+          character.name === 'エミヤ'
       ),
       'number'
     )


### PR DESCRIPTION
close #63 

## 対応箇所
- [x] 宝具を選択できるようにする

- [x] NP計算にエミヤを追加

- [x]  宝具NP計算の宝具タイプ補正値にBusterの場合も追加 --> Busterは0なのでdefaultで大丈夫

- [x] お知らせページにアップデート情報を追記