### PR TITLE
エミヤ, スペースイシュタル, 妖精騎士ランスロット用のロジックを用意

### DIFF
--- a/src/pages/npatk-calculation.vue
+++ b/src/pages/npatk-calculation.vue
@@ -512,6 +512,60 @@ export default {
       }
     }
   },
+  watch: {
+    servantNpType() {
+      if (this.characterName === 'エミヤ' && this.servantNpType === 'Arts') {
+        this.npmultiplier = [600, 750, 825, 862, 900]
+        this.characterNpmultiplier = this.npmultiplier[0]
+        this.npChargeLv = 1
+      }
+      if (this.characterName === 'エミヤ' && this.servantNpType === 'Buster') {
+        this.npmultiplier = [400, 500, 550, 575, 600]
+        this.characterNpmultiplier = this.npmultiplier[0]
+        this.npChargeLv = 1
+      }
+      if (
+        this.characterName === '妖精騎士ランスロット' &&
+        this.servantNpType === 'Buster'
+      ) {
+        this.npmultiplier = [300, 400, 450, 475, 500]
+        this.characterNpmultiplier = this.npmultiplier[0]
+        this.npChargeLv = 1
+      }
+      if (
+        this.characterName === '妖精騎士ランスロット' &&
+        this.servantNpType === 'Arts'
+      ) {
+        this.npmultiplier = [900, 1200, 1350, 1425, 1500]
+        this.characterNpmultiplier = this.npmultiplier[0]
+        this.npChargeLv = 1
+      }
+      if (
+        this.characterName === 'スペースイシュタル' &&
+        this.servantNpType === 'Buster'
+      ) {
+        this.npmultiplier = [300, 400, 450, 475, 500]
+        this.characterNpmultiplier = this.npmultiplier[0]
+        this.npChargeLv = 1
+      }
+      if (
+        this.characterName === 'スペースイシュタル' &&
+        this.servantNpType === 'Quick'
+      ) {
+        this.npmultiplier = [600, 800, 900, 950, 1000]
+        this.characterNpmultiplier = this.npmultiplier[0]
+        this.npChargeLv = 1
+      }
+      if (
+        this.characterName === 'スペースイシュタル' &&
+        this.servantNpType === 'Arts'
+      ) {
+        this.npmultiplier = [450, 600, 675, 712, 750]
+        this.characterNpmultiplier = this.npmultiplier[0]
+        this.npChargeLv = 1
+      }
+    }
+  },
   // データの初期化 Vuex
   created() {
     this.$store.dispatch('characters/init')


### PR DESCRIPTION
エミヤ, スペースイシュタル, 妖精騎士ランスロットは宝具タイプによって宝具倍率が切り替わるので対応した。

メモ
処理の共通化をしたい