### PR TITLE
【トップページ】タイトルのレスポンシブ対応

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -21,12 +21,23 @@
       </v-col>
 
       <v-col
-        v-if="!$vuetify.breakpoint.xs"
+        v-if="$vuetify.breakpoint.lg || $vuetify.breakpoint.xl"
         sm="4"
         md="4"
         class="text-center align-self-center city"
       >
         <h1 class="top-title text-gradient" style="font-size: 70px">
+          FGO Calculator
+        </h1>
+      </v-col>
+
+      <v-col
+        v-if="$vuetify.breakpoint.sm || $vuetify.breakpoint.md"
+        sm="4"
+        md="4"
+        class="text-center align-self-center city"
+      >
+        <h1 class="top-title" style="font-size: 56px">
           FGO Calculator
         </h1>
       </v-col>


### PR DESCRIPTION
## 概要
iPadでトップページのタイトルが見切れてるので修正

### 原因
CSSのグラデーション

### 対応
`$vuetify.breakpoint`

### VuetifyのDisplay Break Points
- xs: スマホ
- sm, md: タブレット
- lg, xl: PC

https://vuetifyjs.com/ja/features/breakpoints/

### チェックリスト

- [x] PC: グラデーションが効いてること
- [x]  タブ: color白
- [x] SP: color白
- [x] デバイスによって「タイトルが表示されない」問題が発生してないこと