### PR TITLE
generateのfallback設定を施して本番で正常に404ページを表示する

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,6 +4,9 @@ import webpack from 'webpack'
 export default {
   ssr: true,
   target: 'static',
+  generate: {
+    fallback: true
+  },
   /*
    ** Headers of the page
    */


### PR DESCRIPTION
close #158 

## 対応
```js
// nuxt.config.js
export default {
  generate: {
    fallback: true
  }
}
```

公式
https://nuxtjs.org/ja/docs/configuration-glossary/configuration-generate/#fallback