### PR TITLE
イベント特攻機能を追加した

### DIFF
--- a/src/components/calculator/Npatk/ResultCard.vue
+++ b/src/components/calculator/Npatk/ResultCard.vue
@@ -253,6 +253,10 @@ export default {
       this.classCompatibility = 2.0
       this.attributeCompatibility = 1.0
       this.$emit('reset-val')
+    },
+    resetCompatibility() {
+      this.classCompatibility = 2.0
+      this.attributeCompatibility = 1.0
     }
   }
 }

--- a/src/pages/npatk-calculation.vue
+++ b/src/pages/npatk-calculation.vue
@@ -220,6 +220,7 @@
                 :error-messages="errors"
                 type="number"
                 class="mr-4"
+                :class="{ 'event-buff-label': isEventCharacter }"
                 color="teal"
               ></v-text-field>
             </validation-provider>
@@ -259,6 +260,7 @@
                 :error-messages="errors"
                 type="number"
                 class="mr-4"
+                :class="{ 'event-buff-label': isNpBuffEventCharacter }"
                 color="teal"
               ></v-text-field>
             </validation-provider>
@@ -397,6 +399,7 @@
     <client-only>
       <ResultCard
         v-if="!$vuetify.breakpoint.xs"
+        ref="child"
         :character-class="characterClass"
         :character-name="characterName"
         :character-atk="characterAtk"
@@ -509,7 +512,9 @@ export default {
       sAtkBuff: 0, // 特攻バフ倍率 (special atk buff)
       npBuff: 0, // 宝具威力バフ倍率
       sNpAtkBuff: 0, // 特攻宝具バフ倍率 (special noble phantasm atk buff)
-      dressAtk: 0 // 概念礼装のATK
+      dressAtk: 0, // 概念礼装のATK
+      isEventCharacter: false,
+      isNpBuffEventCharacter: false
     }
   },
   computed: {
@@ -603,6 +608,7 @@ export default {
       for (let i = 0; i < this.characters.length; i++) {
         const character = this.characters[i]
         if (character.name === characterName) {
+          this.resetBuffSystem()
           this.atk = character.atk // 「攻撃力」を一旦配列で取得
           this.characterAtk = this.atk[0] // デフォルトの攻撃力
           this.npChargeLv = 1 // 「宝具レベル」を１にする
@@ -611,11 +617,11 @@ export default {
           this.setSelectLv(character)
           this.setNpType(character)
           this.setClassCompatibility(character)
+          this.setEventCharacterBuff(character)
         }
       }
     },
     setSelectLv(character) {
-      this.selectedLv = 0
       switch (character.rarity) {
         case 1:
           this.selectLv = [60, 100, 110, 120]
@@ -666,6 +672,43 @@ export default {
           break
       }
     },
+    setEventCharacterBuff(character) {
+      this.isEventCharacter = false
+      this.isNpBuffEventCharacter = false
+      // 事件簿コラボ
+      // グレイは宝具も50%
+      if (character.name === 'グレイ') {
+        this.isEventCharacter = true
+        this.isNpBuffEventCharacter = true
+        this.sAtkBuff = 100
+        this.npBuff = 50
+      } else if (character.name === 'アストライア') {
+        this.isEventCharacter = true
+        this.sAtkBuff = 100
+      } else if (
+        character.name === 'アルトリア〔オルタ〕' ||
+        character.name === 'モリアーティ' ||
+        character.name === 'イスカンダル' ||
+        character.name === 'アレキサンダー' ||
+        character.name === 'ダヴィンチ（キャスター）' ||
+        character.name === 'バベッジ' ||
+        character.name === 'エミヤ（アサシン）'
+      ) {
+        this.isEventCharacter = true
+        this.sAtkBuff = 50
+      } else if (
+        character.name === 'アルトリア〔ランサーオルタ〕' ||
+        character.name === 'ナーサリー' ||
+        character.name === 'シェイクスピア' ||
+        character.name === 'ジャック' ||
+        character.name === '坂田金時' ||
+        character.name === 'バニヤン' ||
+        character.name === 'サリエリ'
+      ) {
+        this.isEventCharacter = true
+        this.sAtkBuff = 30
+      }
+    },
     onChangeLv(selectedLv) {
       if (
         selectedLv === 60 ||
@@ -706,6 +749,25 @@ export default {
     openDisplay() {
       this.$refs.dlg.isDisplay = true
     },
+    resetBuffSystem() {
+      this.fou = 1000
+      this.characterAtk = 0
+      this.npChargeLv = 0
+      this.characterNpmultiplier = 0
+      this.servantNpType = ''
+      this.atkBuff = 0
+      this.cardBuff = 0
+      this.sAtkBuff = 0
+      this.npBuff = 0
+      this.sNpAtkBuff = 0
+      this.dressAtk = 0
+      if (!this.$vuetify.breakpoint.xs) {
+        this.$refs.child.resetCompatibility()
+      } else {
+        this.classCompatibility = 2.0
+        this.attributeCompatibility = 1.0
+      }
+    },
     resetAll() {
       this.characterClass = ''
       this.characterName = ''
@@ -724,6 +786,8 @@ export default {
       this.dressAtk = 0
       this.classCompatibility = 2.0
       this.attributeCompatibility = 1.0
+      this.isEventCharacter = false
+      this.isNpBuffEventCharacter = false
     }
   },
   head() {
@@ -743,10 +807,15 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
 input[type='number']::-webkit-outer-spin-button,
 input[type='number']::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
+}
+.event-buff-label {
+  .v-label {
+    color: #ffa726;
+  }
 }
 </style>


### PR DESCRIPTION
## 概要
close #157 #165

## イベント特攻機能
- イベント特攻対象のサーヴァントが選択されたら、指定された数値を特攻バフに自動入力する
- 「グレイ」は宝具威力UPバフも追加
- イベント特攻対象のサーヴァントが選択されたら、ラベルの文字カラーをオレンジにする
- 1/12(水)から開始の事件簿コラボの内容を反映
<img width="949" alt="スクリーンショット 2022-01-09 18 03 59" src="https://user-images.githubusercontent.com/55835461/148680373-0d6bc875-c0f0-4e92-9376-3978ff6bbb86.png">
<img width="943" alt="スクリーンショット 2022-01-09 18 04 54" src="https://user-images.githubusercontent.com/55835461/148680376-944b5c0b-224e-4514-8d36-83aadd670028.png">

<img width="314" alt="スクリーンショット 2022-01-09 20 33 52" src="https://user-images.githubusercontent.com/55835461/148680466-f44a2319-b440-422c-9db1-0dcd4d321ff4.png">



## サーヴァント選択時のバフ系統のリセット機能
- サーヴァントを再選択した時にバフの数値やクラス相性選択をリセットする