### PR TITLE
宝具後のNPリチャージ値を表示

### DIFF
--- a/src/components/calculator/NpAcquisition/FixedFooter.vue
+++ b/src/components/calculator/NpAcquisition/FixedFooter.vue
@@ -10,7 +10,12 @@
           reactive
           class="mt-4 mb-2"
         ></v-progress-linear>
-        <strong class="mt-1">NP {{ totalAcquisitionAmount }}％</strong>
+        <strong class="mt-1">
+          NP {{ totalAcquisitionAmount }}％
+          <span v-if="npRecharge > 0" style="font-size: 14px">
+            + リチャージ {{ npRecharge }}％
+          </span>
+        </strong>
       </v-col>
 
       <v-col cols="4">
@@ -57,6 +62,10 @@ export default {
     },
     npAcquisitionBuff: {
       type: [String, Number],
+      required: true
+    },
+    npRecharge: {
+      type: Number,
       required: true
     }
   },

--- a/src/components/calculator/NpAcquisition/ResultCard.vue
+++ b/src/components/calculator/NpAcquisition/ResultCard.vue
@@ -15,7 +15,12 @@
     <v-card-text class="mt-12">
       <v-row no-gutters>
         <v-col cols="6" sm="6" md="6">
-          <strong class="title">NP {{ totalAcquisitionAmount }}％</strong>
+          <strong class="title">
+            NP {{ totalAcquisitionAmount }}％
+            <span v-if="npRecharge > 0" style="font-size: 16px">
+              + リチャージ {{ npRecharge }}％
+            </span>
+          </strong>
           <v-progress-linear
             :value="totalAcquisitionAmount"
             rounded
@@ -117,6 +122,10 @@ export default {
     },
     ocSkills: {
       type: Array,
+      required: true
+    },
+    npRecharge: {
+      type: Number,
       required: true
     }
   },

--- a/src/mixins/np-skill/np-recharge.js
+++ b/src/mixins/np-skill/np-recharge.js
@@ -1,0 +1,21 @@
+export default {
+  methods: {
+    // NPリチャージ
+    setNpSkillNpRecharge(character) {
+      if (
+        character.name === 'ダヴィンチ（ライダー）' ||
+        character.name === 'BB' ||
+        character.name === 'ボイジャー'
+      ) {
+        this.npRecharge += 20
+        this.npSkills.push({ description: 'NPチャージ(20%)' })
+      } else if (
+        character.name === '両儀式（セイバー）' ||
+        character.name === '水着アルトリア〔オルタ〕'
+      ) {
+        this.npRecharge += 10
+        this.npSkills.push({ description: 'NPチャージ(10%)' })
+      }
+    }
+  }
+}

--- a/src/mixins/oc-skill/np-recharge.js
+++ b/src/mixins/oc-skill/np-recharge.js
@@ -1,0 +1,24 @@
+export default {
+  methods: {
+    // NPリチャージ
+    setOcSkillNpRecharge(characterName) {
+      if (characterName === 'メディア') {
+        const ocUpPrcentages = [20, 40, 60, 80, 100]
+        this.changeNpRecharge(ocUpPrcentages)
+      } else if (characterName === '水着アルトリア') {
+        const ocUpPrcentages = [20, 25, 30, 35, 40]
+        this.changeNpRecharge(ocUpPrcentages)
+      } else if (characterName === 'パールヴァティー') {
+        const ocUpPrcentages = [10, 15, 20, 25, 30]
+        this.changeNpRecharge(ocUpPrcentages)
+      } else if (characterName === '水着エレナ') {
+        const ocUpPrcentages = [10, 12.5, 15, 17.5, 20]
+        this.changeNpRecharge(ocUpPrcentages)
+      }
+    },
+    changeNpRecharge(ocUpPrcentages) {
+      this.npRecharge = ocUpPrcentages[this.selectingOcUpPrcentage - 1]
+      this.ocSkills.push({ description: `NPチャージ(${this.npRecharge}%)` })
+    }
+  }
+}

--- a/src/pages/npaquisition-calculation.vue
+++ b/src/pages/npaquisition-calculation.vue
@@ -255,6 +255,7 @@
         :possession-skills="possessionSkills"
         :np-skills="npSkills"
         :oc-skills="ocSkills"
+        :np-recharge="npRecharge"
         @reset-val="resetAll"
       />
       <!-- スマホの場合、固定フッター用意 -->
@@ -269,6 +270,7 @@
         :enemy-class="enemyClass"
         :enemy-count="enemyCount"
         :np-acquisition-buff="npAcquisitionBuff"
+        :np-recharge="npRecharge"
         @reset-val="resetAll"
       />
     </client-only>
@@ -294,12 +296,14 @@ import PossessionSkillNpAcquisitionBuff from '../mixins/possession-skill/np-acqu
 import NpSkillArtsBuff from '../mixins/np-skill/arts-buff'
 import NpSkillQuickBuff from '../mixins/np-skill/quick-buff'
 import NpSkillQuickDown from '../mixins/np-skill/quick-down'
+import NpSkillNpRecharge from '../mixins/np-skill/np-recharge'
 
 import OcSkillArtsBuff from '../mixins/oc-skill/arts-buff'
 import OcSkillArtsDown from '../mixins/oc-skill/arts-down'
 import OcSkillQuickBuff from '../mixins/oc-skill/quick-buff'
 import OcSkillQuickDown from '../mixins/oc-skill/quick-down'
 import OcSkillNpAcquisitionBuff from '../mixins/oc-skill/np-acquisition-buff'
+import OcSkillNpRecharge from '../mixins/oc-skill/np-recharge'
 
 import SelectClass from '../mixins/select-class'
 import Dialog from '@/components/calculator/NpAcquisition/Dialog'
@@ -329,11 +333,13 @@ export default {
     NpSkillArtsBuff,
     NpSkillQuickBuff,
     NpSkillQuickDown,
+    NpSkillNpRecharge,
     OcSkillArtsBuff,
     OcSkillArtsDown,
     OcSkillQuickBuff,
     OcSkillQuickDown,
     OcSkillNpAcquisitionBuff,
+    OcSkillNpRecharge,
     SelectClass
   ],
   data() {
@@ -408,7 +414,8 @@ export default {
       ],
       selectingOcUpPrcentage: 1,
       hadSelectedOcUpPrcentage: null,
-      selectableOcUpPrcentages: [1, 2, 3, 4, 5]
+      selectableOcUpPrcentages: [1, 2, 3, 4, 5],
+      npRecharge: 0
     }
   },
   computed: {},
@@ -424,6 +431,14 @@ export default {
       }
       if (this.characterName === 'メリュジーヌ') {
         this.setOcSkillNpAcquisitionBuff(this.characterName)
+      }
+      if (
+        this.characterName === 'メディア' ||
+        this.characterName === '水着アルトリア' ||
+        this.characterName === 'パールヴァティー' ||
+        this.characterName === '水着エレナ'
+      ) {
+        this.setOcSkillNpRecharge(this.characterName)
       }
     }
   },
@@ -474,6 +489,8 @@ export default {
       this.setNpSkillQuickBuff(character)
       // クイック耐性Down
       this.setNpSkillQuickDown(character)
+      // 宝具リチャージ
+      this.setNpSkillNpRecharge(character)
 
       // 宝具OC
       // アーツバフ
@@ -486,6 +503,8 @@ export default {
       this.setOcSkillQuickDown(character.name)
       // NP獲得量UP
       this.setOcSkillNpAcquisitionBuff(character.name)
+      // 宝具リチャージ
+      this.setOcSkillNpRecharge(character.name)
 
       if (character.card === 'A') {
         this.setClassSkillArtsBuff(character)
@@ -543,6 +562,7 @@ export default {
       this.ocSkills = []
       this.selectingOcUpPrcentage = 1
       this.hadSelectedOcUpPrcentage = null
+      this.npRecharge = 0
     },
     resetAll() {
       this.characterClass = ''
@@ -561,6 +581,7 @@ export default {
       this.ocSkills = []
       this.selectingOcUpPrcentage = 1
       this.hadSelectedOcUpPrcentage = null
+      this.npRecharge = 0
     }
   },
   head() {


### PR DESCRIPTION
NPチャージ効果のある宝具を持ったサーヴァントを選択した場合、
計算結果と一緒に`+ リチャージ 20％`のようにリチャージ値を表示させる